### PR TITLE
feat(tokenizer): add support for string literals

### DIFF
--- a/src/specs/tokenizer.spec.ts
+++ b/src/specs/tokenizer.spec.ts
@@ -23,4 +23,14 @@ describe("tokenizer", () => {
       token.rightCurly(),
     ]);
   });
+
+  it("should tokenize string literals", () => {
+    const input = `print('hello!')`;
+    expect(tokenize(input)).toEqual([
+      token.identifier("print"),
+      token.leftParen(),
+      token.stringLiteral("hello!"),
+      token.rightParen(),
+    ]);
+  });
 });


### PR DESCRIPTION
Updates the tokenizer to support parsing string literals.

At the moment, a string literal is defined as any sequence of characters surrounded by a pair of apostrophes, e.g. `'hello world'`. This is a bit different from how strings in real JavaScript are defined; in reality, strings in JavaScript:

- Can be surrounded by either apostrophes (`'`) or double quotes (`"`).
- Cannot contain newline characters.

Neither of these rules apply to the tokenizer for now (i.e. it will parse multiline strings and cannot parse double quotes).

The tokenizer will parse a string literal into a `StringLiteral` token that looks like this:

```ts
token = {
  type: TokenType.StringLiteral,
  value: "hello world"
}
```